### PR TITLE
doc: correct ArkEnv.reset return description

### DIFF
--- a/ark/env/ark_env.py
+++ b/ark/env/ark_env.py
@@ -102,8 +102,9 @@ class ArkEnv(Env, InstanceNode, ABC):
     
     def reset(self):
         '''
-        return obs, terminated, truncated
-        @rtype: Tuple[Any, bool, bool]
+        Returns a tuple (obs, info) where ``info`` contains termination and
+        truncation data.
+        @rtype: Tuple[Any, Any]
         '''
         #self.suspend_node()
         self.reset_objects()


### PR DESCRIPTION
## Summary
- clarify return documentation for `ArkEnv.reset`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d1527e1b08321b06f60f96766471e