### PR TITLE
Fix typo in listener docstring

### DIFF
--- a/ark/client/comm_handler/listener.py
+++ b/ark/client/comm_handler/listener.py
@@ -51,7 +51,7 @@ class Listener(Subscriber):
         This method is invoked by the parent `Subscriber` class when a new message is received.
         It locks the mutex to safely store the received message in the instance.
 
-        @param t: The time stamp when the message was recieved in nanoseconds.
+        @param t: The time stamp when the message was received in nanoseconds.
         @param channel_name: The name of the channel to subscribe to.
         @param msg: The received message.
         """


### PR DESCRIPTION
## Summary
- fix spelling in `Listener.callback` docstring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d72d18b8083218afd4f1bb5804777