### PR TITLE
Fix typo in base_component comment

### DIFF
--- a/ark/system/component/base_component.py
+++ b/ark/system/component/base_component.py
@@ -102,7 +102,7 @@ class SimToRealComponent(BaseComponent, ABC):
             self.reset_service_name = self.reset_service_name + "sim/" 
       
         
-    # Override killing the node to also shutwodn the driver, freeing up ports etc.
+    # Override killing the node to also shutdown the driver, freeing up ports etc.
     def kill_node(self) -> None:
         # kill driver (close ports, ...)
         self._driver.shutdown_driver()


### PR DESCRIPTION
## Summary
- correct comment describing driver shutdown in `base_component.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d738e3a488321b32a7e22b5ce4c0e