### PR TITLE
Improve client docstrings

### DIFF
--- a/ark/client/comm_handler/multi_channel_listener.py
+++ b/ark/client/comm_handler/multi_channel_listener.py
@@ -10,10 +10,16 @@ from ark.client.comm_handler.multi_comm_handler import MultiCommHandler
 from typing import List
 import copy
 
-class MultiChannelListener(MultiCommHandler): 
+class MultiChannelListener(MultiCommHandler):
     def __init__(
         self, channels: List, lcm_instance: LCM) -> None:
-        
+        """!
+        Initialize listeners for multiple channels.
+
+        @param channels: List of ``(channel_name, channel_type)`` tuples.
+        @param lcm_instance: LCM instance used for communication.
+        """
+
         super().__init__()
 
         self.data = {}

--- a/ark/client/comm_handler/multi_channel_publisher.py
+++ b/ark/client/comm_handler/multi_channel_publisher.py
@@ -10,22 +10,18 @@ from typing import Any, Optional, List, Dict
 from ark.tools.log import log
 
 class MultiChannelPublisher(MultiCommHandler):
-    """
-    A publisher that manages multiple communication channels using LCM (Lightweight Communications and Marshalling).
+    """!
+    Publisher that manages multiple communication channels.
 
-    This class initializes multiple publishers for different channels and handles the publishing of messages
-    to these channels. It supports dynamic channel management by accepting a list of channel names and their
-    corresponding message types during initialization.
-
-    Attributes:
-        _lcm (lcm.LCM): The LCM instance used for publishing messages.
-        data (dict): A dictionary to store data for each channel.
-        _comm_handlers (list of CommHandler): A list of communication handlers for each channel.
+    @note Internally creates one :class:`Publisher` per channel.
     """
 
     def __init__(self, channels: List, lcm_instance: LCM) -> None:
-        """
-        Initializes the MultiChannelPublisher with specified channels.
+        """!
+        Initialize the publisher with a list of channels.
+
+        @param channels: List of ``(channel_name, channel_type)`` tuples.
+        @param lcm_instance: LCM instance used for publishing.
         """
         
         super().__init__()
@@ -37,13 +33,10 @@ class MultiChannelPublisher(MultiCommHandler):
             self._comm_handlers.append(publisher)
 
     def publish(self, messages_to_publish: Dict[str, Any]) -> None:
-        """
-        Publishes messages to their respective channels.
+        """!
+        Publish messages to their respective channels.
 
-        This method iterates over all registered communication handlers and publishes the corresponding
-        message to each channel. It expects a dictionary where keys are channel names and values are the
-        messages to be published.
-
+        @param messages_to_publish: Mapping of channel names to messages.
         """
         for publisher in self._comm_handlers:
             channel_name = publisher.channel_name

--- a/ark/client/comm_handler/service.py
+++ b/ark/client/comm_handler/service.py
@@ -22,17 +22,17 @@ class Service(CommHandler):
         port: int = None,
         is_default = False
     ):
-        """
+        """!
         Initialize the service.
 
-        :param name: Name of the service.
-        :param req_type: Request message class with encode/decode methods.
-        :param resp_type: Response message class with encode/decode methods.
-        :param callback: Function to handle the request and return a response.
-        :param registry_host: Host of the registry server.
-        :param registry_port: Port of the registry server.
-        :param host: Host to bind the service. If None, binds to the local network interface.
-        :param port: Port to bind the service. If None, a random free port is chosen.
+        @param name: Name of the service.
+        @param req_type: Request message class with ``encode``/``decode``.
+        @param resp_type: Response message class with ``encode``/``decode``.
+        @param callback: Callback handling the request.
+        @param registry_host: Registry server host.
+        @param registry_port: Registry server port.
+        @param host: Optional host to bind the service.
+        @param port: Optional port to bind the service.
         """
         self.service_name = name
         self.comm_type = "Service"
@@ -51,7 +51,11 @@ class Service(CommHandler):
         self.registered = self.register_with_registry()
 
     def _get_local_ip(self) -> str:
-        """Get the local IP address of the machine."""
+        """!
+        Get the local IP address of the machine.
+
+        @return: Detected local IP address.
+        """
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         s.settimeout(0)
         try:
@@ -64,13 +68,21 @@ class Service(CommHandler):
         return local_ip
 
     def _find_free_port(self) -> int:
-        """Find a free port to bind the service."""
+        """!
+        Find a free port to bind the service.
+
+        @return: Available port number.
+        """
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind((self.host, 0))
             return s.getsockname()[1]
 
     def register_with_registry(self):
-        """Register the service with the registry server."""
+        """!
+        Register the service with the registry server.
+
+        @return: ``True`` on success, ``False`` otherwise.
+        """
         registration = {
             "type": "REGISTER",
             "service_name": self.service_name,
@@ -111,7 +123,9 @@ class Service(CommHandler):
         return True
 
     def _serve(self):
-        """Serve incoming service requests."""
+        """!
+        Serve incoming service requests.
+        """
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind((self.host, self.port))
             s.listen()
@@ -153,7 +167,13 @@ class Service(CommHandler):
                         log.error(f"Service: Error handling request: {e}")
 
     def _recvall(self, conn, n):
-        """Helper function to receive n bytes or return None if EOF is hit."""
+        """!
+        Helper function to receive ``n`` bytes from a socket.
+
+        @param conn: Socket connection.
+        @param n: Number of bytes to read.
+        @return: Received bytes or ``None`` on EOF.
+        """
         data = bytearray()
         while len(data) < n:
             packet = conn.recv(n - len(data))
@@ -176,10 +196,15 @@ class Service(CommHandler):
         return f"{self.service_name}[{self.req_type},{self.resp_type}]"
     
     def restart(self):
+        """!
+        Restart the service communication handlers.
+        """
         return super().restart()
 
     def suspend(self):
-        """Shut down the service and deregister from the registry."""
+        """!
+        Shut down the service and deregister from the registry.
+        """
         if self.deregister_from_registry():
             self._stop_event.set()  # Stop the serving thread
             self.thread.join()  # Wait for the serving thread to terminate
@@ -188,7 +213,11 @@ class Service(CommHandler):
             print("Service shutdown un-gracefully.")
 
     def deregister_from_registry(self) -> bool:
-        """Deregister the service from the registry server and validate the response."""
+        """!
+        Deregister the service from the registry server and validate the response.
+
+        @return: ``True`` if deregistration succeeded.
+        """
         deregistration = {
             "type": "DEREGISTER",
             "service_name": self.service_name,
@@ -229,6 +258,9 @@ class Service(CommHandler):
             return False
         
     def get_info(self):
+        """!
+        Return a dictionary describing this service instance.
+        """
         info = {
             "comms_type": "Service",
             "service_name": self.service_name,
@@ -245,23 +277,16 @@ class Service(CommHandler):
 
 
 def send_service_request(registry_host, registry_port, service_name: str, request: object, response_type: type, timeout: int = 1) -> Any:
-        """
-        Sends a request to a service discovered from a registry.
+        """!
+        Send a request to a service discovered from a registry.
 
-        This method first discovers the target service by querying the registry,
-        then sends a request to the discovered service, and returns the response.
-
-        Args:
-            registry_host (str): The host address of the service registry.
-            registry_port (int): The port of the service registry.
-            service_name (str): The name of the service to be discovered.
-            request (object): The request object to be sent to the discovered service.
-
-        Returns:
-            Any: The response from the service.
-
-        Raises:
-            Exception: If there is an error during discovery or while calling the service.
+        @param registry_host: Host address of the service registry.
+        @param registry_port: Port of the service registry.
+        @param service_name: Name of the service to discover.
+        @param request: Request object to send.
+        @param response_type: Expected response type.
+        @param timeout: Timeout in seconds.
+        @return: The response from the service.
         """
         # TODO timeout addition
         try:
@@ -275,23 +300,15 @@ def send_service_request(registry_host, registry_port, service_name: str, reques
         pass
 
 def __call_service(service_host: str, service_port: int, request, response_type: type) -> Any:
-    """
-    Calls a specific service with the given request and receives a response.
+    """!
+    Call a specific service with the given request and return the response.
 
-    This method establishes a socket connection with the service, sends the request,
-    and waits for the response. It then decodes the response and returns it.
-
-    Args:
-        service_host (str): The host address of the service.
-        service_port (int): The port of the service.
-        request (object): The request to send to the service.
-        response_type (type): The expected type of the response.
-
-    Returns:
-        Any: The response from the service, decoded into the specified response type.
-
-    Raises:
-        RuntimeError: If there is an error while sending the request or receiving the response.
+    @param service_host: Host address of the service.
+    @param service_port: Port of the service.
+    @param request: Request to send to the service.
+    @param response_type: Expected response type.
+    @return: The decoded response object.
+    @raises RuntimeError: If communication fails.
     """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         # Connect to the service
@@ -322,22 +339,12 @@ def __call_service(service_host: str, service_port: int, request, response_type:
         return response
 
 def __recvall(conn: socket.socket, n: int) -> bytes:
-    """
-    Receives `n` bytes of data from the socket connection.
+    """!
+    Receive ``n`` bytes from a socket connection.
 
-    This helper function reads from the socket in chunks until `n` bytes
-    are received. If EOF (End of File) is encountered before `n` bytes are
-    received, it returns None.
-
-    Args:
-        conn (socket.socket): The socket connection to receive data from.
-        n (int): The number of bytes to receive.
-
-    Returns:
-        bytes: The received data as a byte string.
-
-    Raises:
-        None: Returns None if the connection is closed before receiving `n` bytes.
+    @param conn: Socket connection to read from.
+    @param n: Number of bytes to receive.
+    @return: Bytes received or ``None`` if EOF is reached.
     """
     data = bytearray()
     while len(data) < n:
@@ -349,22 +356,14 @@ def __recvall(conn: socket.socket, n: int) -> bytes:
     return bytes(data)
 
 def __discover_service(registry_host: str, registry_port: int, service_name: str):
-    """
-    Discovers the host and port of a service by querying the service registry.
+    """!
+    Discover the host and port of a service by querying the registry.
 
-    This method sends a discovery request to the registry and receives the
-    host and port details of the requested service.
-
-    Args:
-        registry_host (str): The host address of the registry.
-        registry_port (int): The port of the registry.
-        service_name (str): The name of the service to be discovered.
-
-    Returns:
-        tuple: A tuple containing the host and port of the discovered service.
-
-    Raises:
-        RuntimeError: If there is an error during the discovery process.
+    @param registry_host: Host address of the registry.
+    @param registry_port: Port of the registry.
+    @param service_name: Name of the service to discover.
+    @return: ``(host, port)`` tuple of the discovered service.
+    @raises RuntimeError: If discovery fails.
     """
     discovery_request = {"type": "DISCOVER", "service_name": service_name}
     try:

--- a/ark/client/comm_infrastructure/endpoint.py
+++ b/ark/client/comm_infrastructure/endpoint.py
@@ -12,16 +12,11 @@ import os
 class EndPoint:
 
     def __init__(self, global_config) -> None:
-        """
-        Initializes an Endpoint object to interact with the registry and set up LCM communication.
+        """!
+        Initialize an Endpoint object for interacting with the registry and
+        setting up LCM communication.
 
-        Parameters:
-        - registry_host (str): The host address of the registry. Default is "127.0.0.1" (localhost).
-        - registry_port (int): The port number for the registry. Default is 1234.
-        - lcm_network_bounces (int): The Time To Live (TTL) value for LCM multicast messages. Default is 1.
-
-        This constructor sets up the registry host and port as instance variables,
-        and configures the LCM system using a multicast address and the provided TTL.
+        @param global_config: Global configuration containing network settings.
         """
         
         # self.network_config = {
@@ -38,33 +33,16 @@ class EndPoint:
 
 
     def _load_network_config(self, global_config: str | Path | dict | None) -> None:
-        """
-        Loads and updates the network configuration for the current instance from the provided input.
+        """!
+        Load and update the network configuration from the given input.
 
-        This method accepts a string representing the path to a YAML file, a `Path` object pointing
-        to a YAML file, a dictionary containing network configuration data, or `None`. It then attempts
-        to extract and store the 'network' configuration in `self.network_config`. If the file or
-        configuration is missing or invalid, default system settings are used and logged appropriately.
+        This method accepts a string path, a :class:`Path` object, a dictionary
+        or ``None``. The resulting configuration is stored in
+        ``self.network_config``.
 
-        Args:
-            global_config (str | Path | dict | None):
-                - If a string or `Path`, it should point to a valid YAML configuration file containing a
-                'network' key.
-                - If a dictionary, it should include a 'network' key with relevant configuration values.
-                - If `None`, the method will log a warning and use default settings.
-
-        Returns:
-            None or dict:
-                - In most cases, the method updates `self.network_config` in place and returns `None`.
-                - If the YAML file cannot be read, an empty dictionary `{}` is returned early,
-                signaling an error in reading the file.
-
-        Raises:
-            None: This function does not explicitly raise any exceptions. Errors are logged instead.
-
-        Side Effects:
-            - Modifies the `self.network_config` attribute of the instance.
-            - Logs warnings or errors if configuration data is missing or invalid.
+        @param global_config: Path to a YAML file, a dictionary containing the
+            network configuration, or ``None`` to use defaults.
+        @return: ``None``. ``self.network_config`` is updated in place.
         """
         self.network_config = {}
         # extract network part of the global config 

--- a/ark/client/comm_infrastructure/registry.py
+++ b/ark/client/comm_infrastructure/registry.py
@@ -17,7 +17,13 @@ app = typer.Typer()
 
 class Registry(EndPoint):
     def __init__(self, registry_host: str = "127.0.0.1", registry_port: int = 1234, lcm_network_bounces: int = 1):
+        """!
+        Initialize the Registry server instance.
 
+        @param registry_host: Host address for the registry.
+        @param registry_port: Port on which the registry listens.
+        @param lcm_network_bounces: TTL for LCM multicast messages.
+        """
         global_config = {
             "network": {
                 "registry_host": registry_host,
@@ -37,6 +43,13 @@ class Registry(EndPoint):
         self.get_info_service = None  # Placeholder for service
 
     def _callback_get_network_info(self, channel, msg):
+        """!
+        Aggregate information about all nodes in the network.
+
+        @param channel: Unused service channel name.
+        @param msg: Service request message.
+        @return: Populated :class:`network_info_t` message.
+        """
         nodes_info = []
         req = flag_t()
         for service in self.services:
@@ -52,6 +65,12 @@ class Registry(EndPoint):
         return res
 
     def _serve(self):
+        """!
+        Main loop handling incoming registry requests.
+
+        This method listens on the configured host and port, processing
+        registration, deregistration and discovery requests from clients.
+        """
         self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         
@@ -100,7 +119,13 @@ class Registry(EndPoint):
                     continue  # Continue with the next request
 
     def _recvall(self, conn, n):
-        """Helper function to receive n bytes or return None if EOF is hit."""
+        """!
+        Receive ``n`` bytes from a connection.
+
+        @param conn: Socket connection.
+        @param n: Number of bytes to receive.
+        @return: The received bytes or ``None`` if EOF is hit.
+        """
         data = bytearray()
         while len(data) < n:
             packet = conn.recv(n - len(data))
@@ -110,6 +135,12 @@ class Registry(EndPoint):
         return bytes(data)
 
     def _handle_request(self, request):
+        """!
+        Handle an incoming registry request.
+
+        @param request: Parsed request dictionary.
+        @return: Response dictionary to send back to the client.
+        """
         req_type = request.get("type")
         if req_type == "REGISTER":
             service_name = request.get("service_name")
@@ -150,7 +181,11 @@ class Registry(EndPoint):
             return {"status": "ERROR", "message": "Unknown request type"}
 
     def _stop(self):
-        """Stop the server and wait for the thread to finish."""
+        """!
+        Stop the server and wait for the serving thread to finish.
+
+        @return: ``None``
+        """
         log.info("Shutting down server...")
         # Shutdown the info service
         if self.get_info_service:
@@ -166,7 +201,11 @@ class Registry(EndPoint):
         log.info("Registry Server stopped.")
 
     def start(self):
-        """Start the server and monitor for errors."""
+        """!
+        Start the server and monitor for errors.
+
+        This method blocks until the server stops or encounters a fatal error.
+        """
         
         try:
             # Initialize thread to serve requests
@@ -194,12 +233,17 @@ def start(
     registry_host: str = typer.Option("127.0.0.1", "--host", help="The host address for the registry server."),
     registry_port: int = typer.Option(1234, "--port", help="The port for the registry server.")
 ):
-    """Starts the Registry server with specified host and port."""
+    """!
+    Start the Registry server with the specified host and port.
+
+    @param registry_host: Host address for the registry server.
+    @param registry_port: Port for the registry server.
+    """
     server = Registry(registry_host=registry_host, registry_port=registry_port)
     server.start()
 
 def main():
-    """Entry point for the CLI."""
+    """! Entry point for the CLI. """
     app()  # Initializes the Typer CLI
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- reformat client docs using Doxygen style
- add descriptions for service and endpoint handlers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e906427c88321988648d1c34e3020