### PR TITLE
Add info CLI for active nodes, channels, services

### DIFF
--- a/ark/cli.py
+++ b/ark/cli.py
@@ -4,6 +4,7 @@ import typer
 from ark.client.comm_infrastructure import registry
 from ark.tools.ark_graph import ark_graph
 from ark.tools import launcher
+from ark.tools import info
 # from ark.tools.image_viewer import image_viewer
 
 app = typer.Typer()
@@ -11,6 +12,9 @@ app = typer.Typer()
 app.add_typer(registry.app, name="registry")
 app.add_typer(ark_graph.app, name="graph")
 app.add_typer(launcher.app, name="launcher")
+# CLI utilities for inspecting running network
+app.add_typer(info.info, name="info")
+app.add_typer(info.active, name="active")
 # app.add_typer(image_viewer.app, name="image_viewer")
 
 def main():

--- a/ark/tools/info.py
+++ b/ark/tools/info.py
@@ -1,0 +1,68 @@
+import typer
+
+from ark.client.comm_handler.service import send_service_request
+from ark.global_constants import DEFAULT_SERVICE_DECORATOR
+from ark.tools.ark_graph.ark_graph import network_info_lcm_to_dict
+from arktypes import flag_t, network_info_t
+
+info = typer.Typer(help="Query information about the running ARK network")
+active = typer.Typer(help="Inspect active objects")
+
+
+def _fetch_network_info(host: str, port: int) -> dict:
+    req = flag_t()
+    lcm_msg = send_service_request(
+        host,
+        port,
+        f"{DEFAULT_SERVICE_DECORATOR}/GetNetworkInfo",
+        req,
+        network_info_t,
+    )
+    return network_info_lcm_to_dict(lcm_msg)
+
+
+@info.command()
+def nodes(host: str = "127.0.0.1", port: int = 1234):
+    """List active nodes."""
+    data = _fetch_network_info(host, port)
+    for node in data.get("nodes", []):
+        print(node.get("name"))
+
+
+@info.command()
+def channels(host: str = "127.0.0.1", port: int = 1234):
+    """List active channels."""
+    data = _fetch_network_info(host, port)
+    channels = set()
+    for node in data.get("nodes", []):
+        comms = node.get("comms", {})
+        for comp in ("listeners", "subscribers", "publishers"):
+            for ch in comms.get(comp, []):
+                if ch.get("channel_status"):
+                    channels.add(ch.get("channel_name"))
+    for ch in sorted(channels):
+        print(ch)
+
+
+@active.command()
+def services(host: str = "127.0.0.1", port: int = 1234):
+    """List active services."""
+    data = _fetch_network_info(host, port)
+    services = set()
+    for node in data.get("nodes", []):
+        comms = node.get("comms", {})
+        for srv in comms.get("services", []):
+            services.add(srv.get("service_name"))
+    for srv in sorted(services):
+        print(srv)
+
+
+def main():
+    app = typer.Typer()
+    app.add_typer(info, name="info")
+    app.add_typer(active, name="active")
+    app()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `ark.tools.info` with `info` and `active` command groups
- integrate new commands into the main CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866b26d5e048321a97023015358f588