### PR TITLE
Add wheel as build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ conda activate ark_env
 # clone and install the framework
 git clone https://github.com/Robotics-Ark/ark_framework.git
 cd ark_framework
-pip install -e .
+pip install .
 cd ..
 
 # clone and install ark_types
 git clone https://github.com/Robotics-Ark/ark_types.git
 cd ark_types
-pip install -e .
+pip install .
 ```
 
 ### macOS
@@ -45,7 +45,7 @@ conda activate ark_env
 # clone and install the framework
 git clone https://github.com/Robotics-Ark/ark_framework.git
 cd ark_framework
-pip install -e .
+pip install .
 
 # pybullet must be installed via conda on macOS
 conda install -c conda-forge pybullet
@@ -54,7 +54,7 @@ cd ..
 # clone and install ark_types
 git clone https://github.com/Robotics-Ark/ark_types.git
 cd ark_types
-pip install -e .
+pip install .
 ```
 
 After installation, verify the command-line tool is available:

--- a/ark/__init__.py
+++ b/ark/__init__.py
@@ -1,1 +1,11 @@
+"""Ark robotics framework package."""
 
+__version__ = "0.1"
+
+__all__ = [
+    "cli",
+    "client",
+    "env",
+    "system",
+    "tools",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,13 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "ark"
-version = "0.1"
+name = "ark-robotics"
+version = "0.1.1"
 description = "Robotics Ark robotics framework"
 readme = "README.md"
 license = {file = "LICENCE"}
 requires-python = ">=3.10"
-authors = [{name = "Robotics Ark"}]
+authors = [{name = "Sarthak Das"}]
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
@@ -37,8 +37,8 @@ dependencies = [
 [project.optional-dependencies]
 test = ["pytest"]
 
-[tool.setuptools.packages]
-find = {include = ["ark", "arktypes", "arktypes.*"]}
+[tool.setuptools.packages.find]
+include = ["ark", "ark.*"]
 
 [project.scripts]
 ark = "ark.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,24 @@
 [build-system]
-requires = ["setuptools>=64"]
+requires = [
+    "setuptools>=64",
+    "wheel",
+]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "ark"
 version = "0.1"
+description = "Robotics Ark robotics framework"
+readme = "README.md"
+license = {file = "LICENCE"}
+requires-python = ">=3.10"
+authors = [{name = "Robotics Ark"}]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+urls = {"Source" = "https://github.com/Robotics-Ark/ark_framework"}
 dependencies = [
     "lcm",
     "colorlog",


### PR DESCRIPTION
## Summary
- declare `wheel` in build-system requirements
- adjust install instructions in README
- add project metadata in pyproject.toml
- expose version in package init

## Testing
- `pip install --no-build-isolation .` *(fails: invalid command 'bdist_wheel')*


------
https://chatgpt.com/codex/tasks/task_e_68712c06a8408321840ed8fc59785a7f